### PR TITLE
nmake makefile and header fix to build a shared lib and the example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 /bin
 /_gnu-make/assert.txt
+_win-nmake/assert.txt

--- a/_win-nmake/makefile
+++ b/_win-nmake/makefile
@@ -1,0 +1,42 @@
+prefix=..
+libdir=$(prefix)\lib\windows
+bindir=$(prefix)\bin\windows
+srcdir=$(prefix)\src
+exampledir=$(prefix)\example
+
+CXX=cl
+AR=lib
+LD=link
+FLAGS=/c /Ox /MD -Gm- /nologo /EHsc
+LDFLAGS=/nologo# /SUBSYSTEM:WINDOWS
+CXXFLAGS= $(FLAGS)
+
+libname=ppkassert
+
+SOURCES=$(srcdir)\pempek_assert.cpp
+
+OBJECTS=$(SOURCES:.cpp=.obj)
+
+all: build-lib build-example
+
+build-lib: $(libdir)\$(libname).lib
+$(srcdir)\pempek_assert.obj: $(srcdir)\pempek_assert.cpp
+	$(CXX) $(CXXFLAGS) -I$(srcdir) $** /Fo$@
+$(libdir):
+	mkdir $(libdir)
+$(libdir)\$(libname).lib: $(libdir) $(srcdir)\pempek_assert.obj
+	$(AR) $(LDFLAGS) $(srcdir)\pempek_assert.obj  /OUT:$@
+
+
+build-example: $(bindir)\example.exe
+$(exampledir)\main.obj: $(exampledir)\main.cpp
+	$(CXX) $(CXXFLAGS) -I$(srcdir) $** /Fo$@
+$(bindir):
+	mkdir $(bindir)
+$(bindir)\example.exe: $(bindir) $(exampledir)\main.obj
+	$(LD) $(LDFLAGS) /LIBPATH:$(libdir) $(exampledir)\main.obj $(libname).lib User32.lib /OUT:$@
+
+
+clean:
+	del $(srcdir)\*.obj $(exampledir)\*.obj
+	rmdir /S /Q $(libdir) $(bindir)

--- a/_win-nmake/makefile
+++ b/_win-nmake/makefile
@@ -5,10 +5,9 @@ srcdir=$(prefix)\src
 exampledir=$(prefix)\example
 
 CXX=cl
-AR=lib
 LD=link
 FLAGS=/c /Ox /MD -Gm- /nologo /EHsc
-LDFLAGS=/nologo# /SUBSYSTEM:WINDOWS
+LDFLAGS=/nologo
 CXXFLAGS= $(FLAGS)
 
 libname=ppkassert
@@ -19,22 +18,22 @@ OBJECTS=$(SOURCES:.cpp=.obj)
 
 all: build-lib build-example
 
-build-lib: $(libdir)\$(libname).lib
+build-lib: $(libdir)\$(libname).dll
 $(srcdir)\pempek_assert.obj: $(srcdir)\pempek_assert.cpp
-	$(CXX) $(CXXFLAGS) -I$(srcdir) $** /Fo$@
+	$(CXX) $(CXXFLAGS) /DBUILDING_PPKASSERT /DUSING_DLL  /I$(srcdir) $** /Fo$@
 $(libdir):
 	mkdir $(libdir)
-$(libdir)\$(libname).lib: $(libdir) $(srcdir)\pempek_assert.obj
-	$(AR) $(LDFLAGS) $(srcdir)\pempek_assert.obj  /OUT:$@
+$(libdir)\$(libname).dll: $(libdir) $(srcdir)\pempek_assert.obj
+	$(LD) $(LDFLAGS) /DLL $(srcdir)\pempek_assert.obj User32.lib /OUT:$@ /IMPLIB:$(libdir)\$(libname).lib
 
 
-build-example: $(bindir)\example.exe
+build-example: $(bindir)\example_shared.exe
 $(exampledir)\main.obj: $(exampledir)\main.cpp
-	$(CXX) $(CXXFLAGS) -I$(srcdir) $** /Fo$@
+	$(CXX) $(CXXFLAGS) /DUSING_DLL /I$(srcdir) $** /Fo$@
 $(bindir):
 	mkdir $(bindir)
-$(bindir)\example.exe: $(bindir) $(exampledir)\main.obj
-	$(LD) $(LDFLAGS) /LIBPATH:$(libdir) $(exampledir)\main.obj $(libname).lib User32.lib /OUT:$@
+$(bindir)\example_shared.exe: $(bindir) $(exampledir)\main.obj
+	$(LD) $(LDFLAGS) /LIBPATH:$(libdir) $(exampledir)\main.obj $(libname).lib /OUT:$@
 
 
 clean:

--- a/src/pempek_assert.h
+++ b/src/pempek_assert.h
@@ -43,6 +43,18 @@
 
 */
 
+#undef PPKASSERT_EXPORT
+#if defined(WIN32) && defined(USING_DLL)
+#  ifdef BUILDING_PPKASSERT
+#    define PPKASSERT_EXPORT __declspec(dllexport)
+#  else
+#    define PPKASSERT_EXPORT __declspec(dllimport)
+#  endif
+#else
+#  define PPKASSERT_EXPORT
+#endif
+
+
 #if !defined(PPK_ASSERT_ENABLED)
   #if !defined(NDEBUG) // if we are in debug mode
     #define PPK_ASSERT_ENABLED 1 // enable them
@@ -460,7 +472,7 @@
     #define PPK_ASSERT_HANDLE_ASSERT_FORMAT
   #endif
 
-    AssertAction::AssertAction handleAssert(const char* file,
+    PPKASSERT_EXPORT AssertAction::AssertAction handleAssert(const char* file,
                                             int line,
                                             const char* function,
                                             const char* expression,
@@ -468,10 +480,10 @@
                                             bool* ignoreLine,
                                             const char* message, ...) PPK_ASSERT_HANDLE_ASSERT_FORMAT;
 
-    AssertHandler setAssertHandler(AssertHandler handler);
+    PPKASSERT_EXPORT AssertHandler setAssertHandler(AssertHandler handler);
 
-    void ignoreAllAsserts(bool value);
-    bool ignoreAllAsserts();
+    PPKASSERT_EXPORT void ignoreAllAsserts(bool value);
+    PPKASSERT_EXPORT bool ignoreAllAsserts();
 
   #if defined(PPK_ASSERT_CXX11)
 


### PR DESCRIPTION
When compiled with USING_DLL and BUILDING_PPKASSERT flags, one can now create a shared lib, useful for large multi-libs and multi-exe where this module is used everywhere.