### PR TITLE
* support solaris build

### DIFF
--- a/_gnu-make/Makefile
+++ b/_gnu-make/Makefile
@@ -99,7 +99,7 @@ $(bindir)/example: $(srcdir)/pempek_assert.cpp $(srcdir)/pempek_assert.h $(examp
 
 $(bindir)/example_shared: $(srcdir)/pempek_assert.h $(exampledir)/main.cpp
 	mkdir -p $(@D)
-	$(CXX) -o $@ -I $(srcdir) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) -L$(libdir) -lppkassert $(filter-out %.h,$^)
+	$(CXX) -o $@ -I $(srcdir) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) -L$(libdir) $(filter-out %.h,$^) -lppkassert
 	$(if $(postbuild),$(postbuild) $@)
 
 .PHONY: test

--- a/_gnu-make/Makefile
+++ b/_gnu-make/Makefile
@@ -17,6 +17,14 @@ ifeq ($(platform),)
     override platform := mac
     override architecture := $(__uname_m)
   endif
+  ifeq ($(__uname_s),sunos)
+    ifeq ($(CXX),CC)
+      override platform := solariscc
+    else
+      override platform := solaris
+    endif
+    override architecture := $(__uname_m)
+  endif
 endif
 ifeq ($(architecture),)
   override architecture := unknown-architecture
@@ -27,19 +35,43 @@ srcdir := $(realpath ../src)
 exampledir := $(realpath ../example)
 testdir := $(realpath ../test)
 buildir := $(realpath .)/build
-binsubdir := $(platform)-$(architecture)
-bindir := $(prefix)/bin/$(binsubdir)
+subdir := $(platform)-$(architecture)
+bindir := $(prefix)/bin/$(subdir)
+libdir := $(prefix)/lib/$(subdir)
 
 CPPFLAGS := -DPPK_ASSERT_LOG_FILE=\"assert.txt\" -DPPK_ASSERT_LOG_FILE_TRUNCATE
-CXXFLAGS := -O2 -g -Wall -Wextra
+override CXXFLAGS += -O2 -g
 
 ifeq ($(platform),linux)
   GTEST_CXXFLAGS := -pthread
+  SHAREDLIB_FLAGS := -shared -fPIC
+  SONAME_FLAG = -Wl,-soname,$(@F)
+endif
+ifeq ($(platform),solaris)
+  SHAREDLIB_FLAGS := -shared -fPIC
+  SONAME_FLAG = -Wl,-soname,$(@F)
+endif
+ifeq ($(platform),solariscc)
+  override CXXFLAGS += -features=extensions
+  SHAREDLIB_FLAGS := -G -KPIC
+  SONAME_FLAG = -h $(@F)
+endif
+ifneq ($(platform),solariscc)
+  CXXFLAGS += -Wall -Wextra
 endif
 
-.PHONY: build-test
+.PHONY: build-lib build-test
+build: build-lib
+ifneq ($(platform),solariscc)
 build: build-test
+endif
+build-lib:  $(libdir)/libppkassert.so
 build-test: $(bindir)/test $(bindir)/test-no-stl $(bindir)/test-no-exceptions
+
+$(libdir)/libppkassert.so: $(srcdir)/pempek_assert.cpp $(srcdir)/pempek_assert.h
+	mkdir -p $(@D)
+	$(CXX) $(SHAREDLIB_FLAGS) $(CPPFLAGS) $(CXXFLAGS) $(SONAME_FLAG) -o $@ -I$(srcdir) $(srcdir)/pempek_assert.cpp
+	$(if $(postbuild),$(postbuild) $@)
 
 $(bindir)/test: $(srcdir)/pempek_assert.cpp $(srcdir)/pempek_assert.h $(testdir)/pempek_assert_test.cpp $(testdir)/gtest/gtest-all.cc $(testdir)/gtest/gtest.h
 	mkdir -p $(@D)
@@ -58,11 +90,16 @@ $(bindir)/test-no-exceptions: $(srcdir)/pempek_assert.cpp $(srcdir)/pempek_asser
 
 .PHONY: build-example
 build: build-example
-build-example: $(bindir)/example
+build-example: $(bindir)/example $(bindir)/example_shared
 
 $(bindir)/example: $(srcdir)/pempek_assert.cpp $(srcdir)/pempek_assert.h $(exampledir)/main.cpp
 	mkdir -p $(@D)
 	$(CXX) -o $@ -I $(srcdir) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(filter-out %.h,$^)
+	$(if $(postbuild),$(postbuild) $@)
+
+$(bindir)/example_shared: $(srcdir)/pempek_assert.h $(exampledir)/main.cpp
+	mkdir -p $(@D)
+	$(CXX) -o $@ -I $(srcdir) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) -L$(libdir) -lppkassert $(filter-out %.h,$^)
 	$(if $(postbuild),$(postbuild) $@)
 
 .PHONY: test
@@ -74,3 +111,4 @@ test : build-test
 clean:
 	rm -rf $(buildir)
 	rm -rf $(bindir)
+	rm -rf $(libdir)


### PR DESCRIPTION
Solaris build:
    * with g++ by default
    * Oracle Studio if gmake CXX=CC
* build a shared library and an example using it
* allow passing additional CXXFLAGS from the command line (e.g. gmake CXXFLAGS=-m64)
* disable building tests with Oracle Studio which gtest is not happy with

The reason to also build a shared lib is for huge projects with hundreds of libraries and executables, where we definitely shouldn't add directly the .cpp source in each lib and exe.