### PR TITLE
using PPK_ASSERT_NULLPTR in the assert macro to circumvent a warning

### DIFF
--- a/src/ppk_assert.h
+++ b/src/ppk_assert.h
@@ -177,7 +177,7 @@
           if (PPK_ASSERT_LIKELY(expression) || ppk::assert::implementation::ignoreAllAsserts());\
           else\
           {\
-            if (ppk::assert::implementation::handleAssert(PPK_ASSERT_FILE, PPK_ASSERT_LINE, PPK_ASSERT_FUNCTION, #expression, level, 0, __VA_ARGS__) == ppk::assert::implementation::AssertAction::Break)\
+            if (ppk::assert::implementation::handleAssert(PPK_ASSERT_FILE, PPK_ASSERT_LINE, PPK_ASSERT_FUNCTION, #expression, level, PPK_ASSERT_NULLPTR, __VA_ARGS__) == ppk::assert::implementation::AssertAction::Break)\
               PPK_ASSERT_DEBUG_BREAK();\
           }\
         }\
@@ -227,7 +227,7 @@
           else\
           {\
             _PPK_ASSERT_WFORMAT_AS_ERROR_BEGIN\
-            if (ppk::assert::implementation::handleAssert(PPK_ASSERT_FILE, PPK_ASSERT_LINE, PPK_ASSERT_FUNCTION, #expression, level, 0, __VA_ARGS__) == ppk::assert::implementation::AssertAction::Break)\
+            if (ppk::assert::implementation::handleAssert(PPK_ASSERT_FILE, PPK_ASSERT_LINE, PPK_ASSERT_FUNCTION, #expression, level, PPK_ASSERT_NULLPTR, __VA_ARGS__) == ppk::assert::implementation::AssertAction::Break)\
               PPK_ASSERT_DEBUG_BREAK();\
             _PPK_ASSERT_WFORMAT_AS_ERROR_END\
           }\


### PR DESCRIPTION
The warning in question is from GCC and is this: "-Wzero-as-null-pointer-constant"

I have silenced all other warnings with pragmas around the inclusion of the header, but this one is from the macros used in user code.